### PR TITLE
feat(compaction): implement different compaction policies for leveldb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ cmake-*
 build/
 out/
 evaluation/
+
+*default.txt
+log/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ else (WIN32)
   set(LEVELDB_PLATFORM_NAME LEVELDB_PLATFORM_POSIX)
 endif (WIN32)
 
+find_package(gflags REQUIRED)
+include_directories(${GFLAGS_INCLUDE_DIR})
 
 add_subdirectory(mod/ft)
 add_subdirectory(mod/pgm)
@@ -371,6 +373,9 @@ if(LEVELDB_BUILD_TESTS)
         "${test_file}"
     )
     target_link_libraries("${test_target_name}" leveldb)
+    if (${test_file} MATCHES ".*test_compaction.cc$")
+      target_link_libraries("${test_target_name}" gflags)
+    endif()
     target_compile_definitions("${test_target_name}"
       PRIVATE
         ${LEVELDB_PLATFORM_NAME}=1
@@ -428,6 +433,8 @@ if(LEVELDB_BUILD_TESTS)
     leveldb_test("${PROJECT_SOURCE_DIR}/mod/read.cc")
     leveldb_test("${PROJECT_SOURCE_DIR}/mod/read_cold.cc")
     leveldb_test("${PROJECT_SOURCE_DIR}/mod/gen_dbtrace.cpp")
+    leveldb_test("${PROJECT_SOURCE_DIR}/mod/test_compaction.cc")
+    leveldb_test("${PROJECT_SOURCE_DIR}/mod/printdb.cc")
 
     # TODO(costan): This test also uses
     #               "${PROJECT_SOURCE_DIR}/util/env_{posix|windows}_test_helper.h"

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -44,6 +44,12 @@
 
 namespace leveldb {
 
+namespace config {
+  int kL0_CompactionTrigger = 4;
+  int kL0_SlowdownWritesTrigger = 8;
+  int kL0_StopWritesTrigger = 12;
+}
+
 const int kNumNonTableCacheFiles = 10;
 
 // Information kept for every waiting writer
@@ -555,9 +561,10 @@ Status DBImpl::WriteLevel0Table(MemTable* mem, VersionEdit* edit,
   if (s.ok() && meta.file_size > 0) {
     const Slice min_user_key = meta.smallest.user_key();
     const Slice max_user_key = meta.largest.user_key();
-    if (base != nullptr) {
-      level = base->PickLevelForMemTableOutput(min_user_key, max_user_key);
-    }
+    // Put memtable to L0
+    // if (base != nullptr) {
+    //   level = base->PickLevelForMemTableOutput(min_user_key, max_user_key);
+    // }
     edit->AddFile(level, meta.number, meta.file_size, meta.smallest,
                   meta.largest);
 
@@ -1046,9 +1053,26 @@ Status DBImpl::InstallCompactionResults(CompactionState* compact) {
   // Add compaction outputs
   compact->compaction->AddInputDeletions(compact->compaction->edit());
   const int level = compact->compaction->level();
+  int target_level = level + 1;
+  if (options_.compaction_policy != kCompactionStyleLevel) {
+    if (options_.compaction_policy != kCompactionStyleLazyLevel || target_level != options_.max_logical_level - 1) {
+      // need to find an empty level
+      int target_start_physical_level = GetStartPhysicalLevel(target_level, &options_);
+      int target_end_physical_level = GetEndPhysicalLevel(target_level, &options_);
+      for (int j = target_end_physical_level - 1; j >= target_start_physical_level; j--) {
+        if (versions_->NumLevelFiles(j) == 0) {
+          target_level = j;
+          break;
+        }
+      }
+    } else {
+      // lazy level compaction to the last level
+      target_level = GetStartPhysicalLevel(target_level, &options_);
+    }
+  }
   for (size_t i = 0; i < compact->outputs.size(); i++) {
     const CompactionState::Output& out = compact->outputs[i];
-    compact->compaction->edit()->AddFile(level + 1, out.number, out.file_size,
+    compact->compaction->edit()->AddFile(target_level, out.number, out.file_size,
                                          out.smallest, out.largest);
   }
   return versions_->LogAndApply(compact->compaction->edit(), &mutex_);
@@ -1083,7 +1107,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
   bool has_current_user_key = false;
   SequenceNumber last_sequence_for_key = kMaxSequenceNumber;
 
-//  vector<string> keys;
 
   for (; input->Valid() && !shutting_down_.load(std::memory_order_acquire);) {
     // Prioritize immutable compaction work
@@ -1100,9 +1123,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
     }
 
     Slice key = input->key();
-//    ParsedInternalKey parsed;
-//    ParseInternalKey(key, &parsed);
-//    keys.push_back(parsed.user_key);
 
     if (compact->compaction->ShouldStopBefore(key) &&
         compact->builder != nullptr) {
@@ -1209,6 +1229,8 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 
   mutex_.Lock();
   stats_[compact->compaction->level() + 1].Add(stats);
+  Log(options_.info_log, "compacted from: %d, bytes read: %ld, bytes written: %ld, use time: %ld (%ld secs)",
+      compact->compaction->level(), stats.bytes_read, stats.bytes_written, stats.micros, stats.micros / 1000000);
 
   if (status.ok()) {
     status = InstallCompactionResults(compact);
@@ -1859,6 +1881,14 @@ void DBImpl::PrintFileInfo() {
     ver->PrintAll();
     // std::cout<<"flag4"<<std::endl;
     ver->Unref();
+}
+
+void DBImpl::PrintLevelInfo() {
+  MutexLock l(&mutex_);
+  Version* ver = versions_->current();
+  ver->Ref();
+  ver->PrintLevelSummary();
+  ver->Unref();
 }
 
 Version* DBImpl::GetCurrentVersion() {

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -75,6 +75,7 @@ class DBImpl : public DB {
 
 
   virtual void PrintFileInfo();
+  virtual void PrintLevelInfo();
   Version* GetCurrentVersion();
   void ReturnCurrentVersion(Version* version);
   void WaitForBackground();

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -20,16 +20,16 @@ namespace leveldb {
 // Grouping of constants.  We may want to make some of these
 // parameters set via options.
 namespace config {
-static const int kNumLevels = 7;
+static const int kNumLevels = 64;
 
 // Level-0 compaction is started when we hit this many files.
-static const int kL0_CompactionTrigger = 4;
+extern int kL0_CompactionTrigger;
 
 // Soft limit on number of level-0 files.  We slow down writes at this point.
-static const int kL0_SlowdownWritesTrigger = 8;
+extern int kL0_SlowdownWritesTrigger;
 
 // Maximum number of level-0 files.  We stop writes at this point.
-static const int kL0_StopWritesTrigger = 12;
+extern int kL0_StopWritesTrigger;
 
 // Maximum level to which a new compacted memtable is pushed if it
 // does not create overlap.  We try to push to level 2 to avoid the

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -26,6 +26,10 @@
 #include "port/thread_annotations.h"
 
 namespace leveldb {
+int64_t TotalSizeForLevel(const std::vector<FileMetaData*>* files_, int level, const Options *options);
+int RunNumberLevel(const std::vector<FileMetaData*>* files_, int level, const Options *options);
+int GetStartPhysicalLevel(int logical_level, const Options *options);
+int GetEndPhysicalLevel(int logical_level, const Options *options);
 
 namespace log {
 class Writer;
@@ -117,6 +121,7 @@ class Version {
 
   // print level summary
   void PrintAll() const;
+  void PrintLevelSummary() const;
   int GetFileNum() const;
   // Fill file model data
   bool FillData(const ReadOptions& options, FileMetaData* meta, adgMod::LearnedIndexData* data);
@@ -321,6 +326,8 @@ class VersionSet {
 
   void SetupOtherInputs(Compaction* c);
 
+  void SetupInputsForCompaction(Compaction* c);
+
   // Save current contents to *log
   Status WriteSnapshot(log::Writer* log);
 
@@ -402,7 +409,7 @@ class Compaction {
   VersionEdit edit_;
 
   // Each compaction reads inputs from "level_" and "level_+1"
-  std::vector<FileMetaData*> inputs_[2];  // The two sets of inputs
+  std::vector<FileMetaData*> inputs_[config::kNumLevels];  // The two sets of inputs
 
   // State used to check for number of overlapping grandparent files
   // (parent == level_ + 1, grandparent == level_ + 2)

--- a/include/leveldb/db.h
+++ b/include/leveldb/db.h
@@ -150,6 +150,8 @@ class LEVELDB_EXPORT DB {
   virtual void CompactRange(const Slice* begin, const Slice* end) = 0;
 
   virtual void PrintFileInfo() = 0;
+
+  virtual void PrintLevelInfo() {}
 };
 
 // Destroy the contents of the specified database.

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -31,6 +31,12 @@ enum CompressionType {
   kSnappyCompression = 0x1
 };
 
+enum CompactionPolicy {
+  kCompactionStyleLevel = 0x0,
+  kCompactionStyleTier = 0x1,
+  kCompactionStyleLazyLevel = 0x2
+};
+
 // Options to control the behavior of a database (passed to DB::Open)
 struct LEVELDB_EXPORT Options {
   // Create an Options object with default values for all fields.
@@ -142,6 +148,17 @@ struct LEVELDB_EXPORT Options {
   // Many applications will benefit from passing the result of
   // NewBloomFilterPolicy() here.
   const FilterPolicy* filter_policy = NewBloomFilterPolicy(10);
+
+  // const CompactionPolicy compaction_policy = kCompactionStyleLevel;
+  CompactionPolicy compaction_policy = kCompactionStyleLevel;
+
+  uint64_t max_bytes_for_level_base = 10 * 1048576;
+
+  int max_bytes_for_level_multiplier = 10; // T
+
+  int L0_compaction_trigger = 4; // default 4
+
+  int max_logical_level = 4;
 };
 
 // Options that control read operations

--- a/mod/learned_index.cpp
+++ b/mod/learned_index.cpp
@@ -567,14 +567,6 @@ bool LearnedIndexData::Learned(Version* version, int v_count, int level) {
     return true;
   }
   return false;
-  //        } else {
-  //            if (level_learning_enabled && ++current_seek >= allowed_seek &&
-  //            !learning.exchange(true)) {
-  //                env->ScheduleLearning(&LearnedIndexData::Learn, new
-  //                VersionAndSelf{version, v_count, this, level}, 0);
-  //            }
-  //            return false;
-  //        }
 }
 
 // file model checker, used to be also learning trigger
@@ -588,15 +580,6 @@ bool LearnedIndexData::Learned(Version* version, int v_count,
     return true;
   } else
     return false;
-        //  } else {
-        //      if (file_learning_enabled && (true || level != 0 && level != 1)
-        //       && !learning.exchange(true)) {
-        //         std::cout<<"Checking file model and schedule: "<<learned_not_atomic<< " "<<learned.load()<<std::endl;
-        //          env->ScheduleLearning(( void(*)(void *) )&LearnedIndexData::FileLearn, new
-        //          MetaAndSelf{version, v_count, meta, this, level}, 0);
-        //      }
-        //      return false;
-        //  }
 }
 
 bool LearnedIndexData::FillData(Version* version, FileMetaData* meta) {
@@ -626,10 +609,6 @@ void LearnedIndexData::WriteModel(const string& filename) {
     output_file << "StartAcc"
                 << " " << min_key << " " << max_key << " " << size << " " << level
                 << " " << cost << "\n";
-    // // testing num entires
-    // for (auto& pair : num_entries_accumulated.array) {
-    //   output_file << pair.first << " " << pair.second << "\n";
-    // }
   }
   else if(adgMod::modelmode == 4){
     if(rmi.layer2_size() != 0){

--- a/mod/printdb.cc
+++ b/mod/printdb.cc
@@ -1,0 +1,8 @@
+#include "leveldb/db.h"
+
+int main() {
+  leveldb::Options options;
+  leveldb::DB* db;
+  leveldb::Status status = leveldb::DB::Open(options, "/tmp/db1", &db);
+  db->PrintLevelInfo();
+}

--- a/mod/test_compaction.cc
+++ b/mod/test_compaction.cc
@@ -1,0 +1,149 @@
+#include <cassert>
+#include <chrono>
+#include <iostream>
+#include "leveldb/db.h"
+#include "leveldb/comparator.h"
+#include "util.h"
+#include "stats.h"
+#include "learned_index.h"
+#include <cstring>
+#include "cxxopts.hpp"
+#include <unistd.h>
+#include <fstream>
+#include "../db/version_set.h"
+#include <cmath>
+#include <random>
+#include <fstream>
+#include <numeric>
+#include <algorithm>
+#include <stdlib.h>
+
+#include "gflags/gflags.h"
+
+DEFINE_string(compaction_style, "leveling", "compaction style");
+DEFINE_int32(num_levels, 5, "number of logical levels");
+DEFINE_int64(buffer_size, 2 * 1024 * 1024, "buffer size"); // default 2MB
+DEFINE_int32(T, 10, "size ratios");
+DEFINE_int32(key_size, 24, "key size");
+DEFINE_int32(value_size, 1000, "value size");
+DEFINE_int32(num_ops, 10000000, "number of operations");
+
+std::string PadString(const std::string& s, size_t n) {
+  std::string ret = s;
+  int pad = n - s.size();
+  ret = std::string(pad, '0') + ret;
+  return ret;
+}
+
+leveldb::Options GetLevelingOptions() {
+  leveldb::Options options;
+  options.create_if_missing = true;
+  options.L0_compaction_trigger = 2;
+  options.write_buffer_size = FLAGS_buffer_size;
+  options.max_bytes_for_level_base = FLAGS_buffer_size * FLAGS_T; // size for level 1, default 20MB
+  options.max_bytes_for_level_multiplier = FLAGS_T;
+  options.max_logical_level = FLAGS_num_levels;
+  options.max_file_size = 10 * (1<<20); // 10MB
+
+  
+  leveldb::config::kL0_CompactionTrigger = 2;
+  leveldb::config::kL0_SlowdownWritesTrigger = 2;
+  leveldb::config::kL0_StopWritesTrigger = 4;
+
+  return options;
+}
+
+leveldb::Options GetTieringOptions() {
+  leveldb::Options options;
+  options.create_if_missing = true;
+  options.L0_compaction_trigger = FLAGS_T;
+  options.write_buffer_size = FLAGS_buffer_size;
+  options.max_bytes_for_level_base = FLAGS_buffer_size * FLAGS_T * FLAGS_T; // size for level 1, default 200MB
+  options.max_bytes_for_level_multiplier = FLAGS_T;
+  options.max_logical_level = FLAGS_num_levels;
+  options.max_file_size = 10 * (1<<20); // 10MB
+  options.compaction_policy = leveldb::kCompactionStyleTier;
+
+  leveldb::config::kL0_CompactionTrigger = FLAGS_T;
+  leveldb::config::kL0_SlowdownWritesTrigger = FLAGS_T + 2;
+  leveldb::config::kL0_StopWritesTrigger = FLAGS_T + 4;
+  
+  return options;
+}
+
+leveldb::Options GetLazyLevelOptions() {
+  leveldb::Options options;
+  options.create_if_missing = true;
+  options.L0_compaction_trigger = FLAGS_T;
+  options.write_buffer_size = FLAGS_buffer_size;
+  options.max_bytes_for_level_base = FLAGS_buffer_size * FLAGS_T * FLAGS_T; // size for level 1, default 200MB
+  options.max_bytes_for_level_multiplier = FLAGS_T;
+  options.max_logical_level = FLAGS_num_levels;
+  options.max_file_size = 10 * (1<<20); // 10MB
+  options.compaction_policy = leveldb::kCompactionStyleLazyLevel;
+
+  leveldb::config::kL0_CompactionTrigger = FLAGS_T;
+  leveldb::config::kL0_SlowdownWritesTrigger = FLAGS_T + 2;
+  leveldb::config::kL0_StopWritesTrigger = FLAGS_T + 4;
+  
+  return options;
+}
+
+void PrepareDB(leveldb::DB* db, int total_ops) {
+  while (-- total_ops) {
+    int rng = std::rand() % INT32_MAX;
+    std::string key = PadString(std::to_string(rng), FLAGS_key_size);
+    std::string value = PadString(std::to_string(rng), FLAGS_value_size);
+    auto s = db->Put(leveldb::WriteOptions(), key, value);
+    if (!s.ok()) {
+      std::cout << "Failed to put key: " << key << ": " << s.ToString() << std::endl;
+      return;
+    }
+    if (total_ops % 100000 == 0) {
+      db->PrintLevelInfo();
+      std::cout << "Left: " << total_ops << std::endl;
+      std::cout << "---------" << std::endl;
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  adgMod::MOD = 0;
+  leveldb::Options options;
+  if (FLAGS_compaction_style == "leveling") {
+    std::cout << "leveling compaction" << std::endl;
+    options = GetLevelingOptions();
+  } else if (FLAGS_compaction_style == "tiering") {
+    std::cout << "tiering compaction" << std::endl;
+    options = GetTieringOptions();
+  } else if (FLAGS_compaction_style == "lazylevel") {
+    std::cout << "lazylevel compaction" << std::endl;
+    options = GetLazyLevelOptions();
+  } else {
+    std::cout << "Invalid compaction style: " << FLAGS_compaction_style << std::endl;
+    return 0;
+  }
+  leveldb::DB* db;
+  leveldb::Status status = leveldb::DB::Open(options, "/tmp/db", &db);
+  if (!status.ok()) {
+    std::cout << "Failed to open db: " << status.ToString() << std::endl;
+    return 0;
+  }
+  // db->PrintLevelInfo();
+  PrepareDB(db, FLAGS_num_ops);
+  db->PrintLevelInfo();
+
+  std::cout << "--------------------" << std::endl;
+
+  std::string stat;
+  db->GetProperty("leveldb.stats", &stat);
+  std::cout << stat << std::endl;
+
+  adgMod::levelled_counters[10].Report();
+
+  std::cout << "==================================" << std::endl;
+
+  delete db;
+  return 0;
+}

--- a/test_compaction.sh
+++ b/test_compaction.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+rm -rf /tmp/db
+# build/test_compaction --compaction_style=leveling --num_levels=5 --num_ops=5000000
+# rm -rf /tmp/db
+# build/test_compaction --compaction_style=tiering --num_levels=4 --num_ops=5000000
+build/test_compaction --compaction_style=lazylevel --num_levels=4 --num_ops=5000000

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -818,11 +818,11 @@ class PosixEnv : public Env {
 
         // if the file has been created for longer than wait_time (learn_trigger_time),
         // we can do CBA analysis. else, wait until the file has lived wait_time
-        time_diff = front.first + adgMod::learn_trigger_time - time_start;
-        if (time_diff > 0) {
-          wait_for_time = true;
-          break;
-        }
+        // time_diff = front.first + adgMod::learn_trigger_time - time_start;
+        // if (time_diff > 0) {
+        //   wait_for_time = true;
+        //   break;
+        // }
 
         learning_prepare.pop();
         double score = adgMod::learn_cb_model->CalculateCB(level, front.second.second->file_size);
@@ -844,15 +844,6 @@ class PosixEnv : public Env {
         adgMod::filelearn_count++;
         learn_pq.pop();
       }
-
-      // if we decide to wait, sleep here
-      if (wait_for_time) {
-        // prepare_queue_mutex.Unlock();
-        SleepForMicroseconds((int) (time_diff / 1000));
-        // prepare_queue_mutex.Lock();
-        wait_for_time = false;
-      }
-    // }
   }
 
   static void PrepareLearnEntryPoint(PosixEnv* env) {
@@ -868,8 +859,7 @@ class PosixEnv : public Env {
         // background_thread.detach();
         
     // }
-    PrepareLearnEntryPoint(this);   
-    // if (learning_prepare.empty()) preparing_queue_cv.Signal();
+    PrepareLearnEntryPoint(this);
     learning_prepare.emplace(std::make_pair(time_start, std::make_pair(level, meta)));
     adgMod::newSST_count++;
   }


### PR DESCRIPTION
# Policies to implement
1. Tiering
2. LazyLeveling

Treat each level in LevelDB as a sorted run and merge them when T sorted runs are filled at each **logical** level (i.e., level in the paper).

## Minor changes
1. Enable configuring L0_stop_write and L0_slowdown_write in order to limit the number of sorted runs at L0
2. Build a tool for dumping the status of the db (printdb.cc)